### PR TITLE
Rick additions of Table, Proposition, and Figure formatting

### DIFF
--- a/docs/book/content/calibration/demographics.md
+++ b/docs/book/content/calibration/demographics.md
@@ -58,17 +58,15 @@ We discuss the approach to estimating fertility rates $f_s$, mortality rates $\r
 
   In `OG-USA`, we assume that the fertility rates for each age cohort $f_s$ are constant across time. However, this assumption is conceptually straightforward to relax. Our data for U.S. fertility rates by age come from {cite}`MartinEtAl:2015` National Vital Statistics Report, which is final fertility rate data for 2013. Figure {numref}`FigFertRates` shows the fertility-rate data and the estimated average fertility rates for $E+S=100$.
 
+  ```{figure} ../theory/images/fert_rates.png
+  ---
+  height: 500px
+  name: FigFertRates
+  ---
+  Fertility rates by age ($f_s$) for $E+S=100$
+  ```
 
-```{figure} ../theory/images/fert_rates.png
----
-height: 500px
-name: FigFertRates
----
-Fertility rates by age ($f_s$) for $E+S=100$
-```
-
-
-  The large blue circles are the 2013 U.S. fertility rate data from {cite}`MartinEtAl:2015`. These are 9 fertility rates $[0.3, 12.3, 47.1, 80.7, 105.5, 98.0, 49.3, 10.4, 0.8]$ that correspond to the midpoint ages of the following age (in years) bins $[10-14, 15-17, 18-19, 20-24, 25-29, 30-34, 35-39, 40-44, 45-49]$. In order to get our cubic spline interpolating function to fit better at the endpoints we added to fertility rates of zero to ages 9 and 10, and we added two fertility rates of zero to ages 55 and 56. The blue line in Figure {numref}`FigFertRates` shows the cubic spline interpolated function of the data.
+  The large blue circles are the 2013 U.S. fertility rate data from {cite}`MartinEtAl:2015`. These are 9 fertility rates [0.3, 12.3, 47.1, 80.7, 105.5, 98.0, 49.3, 10.4, 0.8] that correspond to the midpoint ages of the following age (in years) bins [10-14, 15-17, 18-19, 20-24, 25-29, 30-34, 35-39, 40-44, 45-49]. In order to get our cubic spline interpolating function to fit better at the endpoints we added to fertility rates of zero to ages 9 and 10, and we added two fertility rates of zero to ages 55 and 56. The blue line in Figure {numref}`FigFertRates` shows the cubic spline interpolated function of the data.
 
   The red diamonds in Figure {numref}`FigFertRates` are the average fertility rate in age bins spanning households born at the beginning of period 1 (time = 0) and dying at the end of their 100th year. Let the total number of model years that a household lives be $E+S\leq 100$. Then the span from the beginning of period 1 (the beginning of year 0) to the end of period 100 (the end of year 99) is divided up into $E+S$ bins of equal length. We calculate the average fertility rate in each of the $E+S$ model-period bins as the average population-weighted fertility rate in that span. The red diamonds in Figure {numref}`FigFertRates` are the average fertility rates displayed at the midpoint in each of the $E+S$ model-period bins.
 
@@ -77,31 +75,32 @@ Fertility rates by age ($f_s$) for $E+S=100$
 
   The mortality rates in our model $\rho_s$ are a one-period hazard rate and represent the probability of dying within one year, given that an household is alive at the beginning of period $s$. We assume that the mortality rates for each age cohort $\rho_s$ are constant across time. The infant mortality rate of $\rho_0=0.00587$ comes from the 2015 U.S. CIA World Factbook. Our data for U.S. mortality rates by age come from the Actuarial Life Tables of the U.S. Social Security Administration {cite}`SocSec:2015`, from which the most recent mortality rate data is for 2011. Figure {numref}`FigMortRates` shows the mortality rate data and the corresponding model-period mortality rates for $E+S=100$.
 
-```{figure} ../theory/images/mort_rates.png
----
-height: 500px
-name: FigMortRates
----
-Mortality rates by age ($\rho_s$) for $E+S=100$
-```
+  ```{figure} ../theory/images/mort_rates.png
+  ---
+  height: 500px
+  name: FigMortRates
+  ---
+  Mortality rates by age ($\rho_s$) for $E+S=100$
+  ```
 
-<!-- +++
-```{code-cell} ogusa-dev
-:tags: [hide-cell]
-from myst_nb import glue
-import ogusa.parameter_plots as pp
-from ogusa import Specifications
-p = Specifications()
-fig = pp.plot_mort_rates(p)
-glue("mort_rates_plot", fig, display=False)
-```
+  <!-- +++
+  ```{code-cell} ogusa-dev
+  :tags: [hide-cell]
+  from myst_nb import glue
+  import ogusa.parameter_plots as pp
+  from ogusa import Specifications
+  p = Specifications()
+  fig = pp.plot_mort_rates(p)
+  glue("mort_rates_plot", fig, display=False)
+  ```
 
-```{glue:figure} mort_rates_plot
-:figwidth: 750px
-:name: "FigMortRates"
+  ```{glue:figure} mort_rates_plot
+  :figwidth: 750px
+  :name: "FigMortRates"
 
-Mortality rates by age ($\rho_s$) for $E+S=100$
-``` -->
+  Mortality rates by age ($\rho_s$) for $E+S=100$
+  ```
+  -->
 
 
   The mortality rates in Figure {numref}`FigMortRates` are a population-weighted average of the male and female mortality rates reported in {cite}`SocSec:2015`. Figure {numref}`FigMortRates` also shows that the data provide mortality rates for ages up to 111-years-old. We truncate the maximum age in years in our model to 100-years old. In addition, we constrain the mortality rate to be 1.0 or 100 percent at the maximum age of 100.
@@ -117,24 +116,32 @@ Mortality rates by age ($\rho_s$) for $E+S=100$
       i_{s+1} &= \frac{\omega_{s+1,t+1} - (1 - \rho_s)\omega_{s,t}}{\omega_{s+1,t}}\qquad\qquad\forall t\quad\text{and}\quad 1\leq s \leq E+S-1
   ```
 
+  ```{figure} ../theory/images/imm_rates_orig.png
+  ---
+  height: 500px
+  name: FigImmRates
+  ---
+  Immigration rates by age ($i_s$), residual, $E+S=100$
+  ```
 
-+++
-```{code-cell} ogusa-dev
-:tags: [hide-cell]
-from myst_nb import glue
-import ogusa.parameter_plots as pp
-from ogusa import Specifications
-p = Specifications()
-fig = pp.plot_imm_rates(p)
-glue("imm_rates_plot", fig, display=False)
-```
+  <!-- +++
+  ```{code-cell} ogusa-dev
+  :tags: [hide-cell]
+  from myst_nb import glue
+  import ogusa.parameter_plots as pp
+  from ogusa import Specifications
+  p = Specifications()
+  fig = pp.plot_imm_rates(p)
+  glue("imm_rates_plot", fig, display=False)
+  ```
 
-```{glue:figure} imm_rates_plot
-:figwidth: 750px
-:name: "FigImmRates"
+  ```{glue:figure} imm_rates_plot
+  :figwidth: 750px
+  :name: "FigImmRates"
 
-Immigration rates by age ($i_s$), residual, $E+S=100$
-```
+  Immigration rates by age ($i_s$), residual, $E+S=100$
+  ```
+  -->
 
   We calculate our immigration rates for three different consecutive-year-periods of population distribution data (2010 through 2013). Our four years of population distribution by age data come from {cite}`Census:2015`. The immigration rates $i_s$ that we use in our model are the the residuals described in {eq}`EqPopImmRates` averaged across the three periods. Figure {numref}`FigImmRates` shows the estimated immigration rates for $E+S=100$ and given the fertility rates from Section {ref}`SecDemogFert` and the mortality rates from Section {ref}`SecDemogMort`.
 
@@ -144,7 +151,7 @@ Immigration rates by age ($i_s$), residual, $E+S=100$
 ## Population steady-state and transition path
 
   This model requires information about mortality rates $\rho_s$ in order to solve for the household's problem each period. It also requires the steady-state stationary population distribution $\bar{\omega}_{s}$ and population growth rate $\bar{g}_n$ as well as the full transition path of the stationary population distribution $\hat{\omega}_{s,t}$ and population grow rate $\tilde{g}_{n,t}$ from the current state to the steady-state. To solve for the steady-state and the transition path of the stationary population distribution, we write the stationary population dynamic equations {eq}`EqPopLawofmotionStat` and their matrix representation {eq}`EqPopLOMstatmat`.
-  
+
   ```{math}
   :label: EqPopLawofmotionStat
       \hat{\omega}_{1,t+1} &= \frac{(1-\rho_0)\sum_{s=1}^{E+S} f_s\hat{\omega}_{s,t} + i_1\hat{\omega}_{1,t}}{1+\tilde{g}_{n,t+1}}\quad\forall t \\
@@ -168,28 +175,28 @@ Immigration rates by age ($i_s$), residual, $E+S=100$
         \hat{\omega}_{1,t} \\ \hat{\omega}_{2,t} \\ \hat{\omega}_{2,t} \\ \vdots \\ \hat{\omega}_{E+S-1,t} \\ \hat{\omega}_{E+S,t}
       \end{bmatrix}
   ```
-  
+
   We can write system {eq}`EqPopLOMstatmat` more simply in the following way.
-  
+
   ```{math}
   :label: EqPopLOMstatmat2
     \boldsymbol{\hat{\omega}}_{t+1} = \frac{1}{1+g_{n,t+1}}\boldsymbol{\Omega}\boldsymbol{\hat{\omega}}_t \quad\forall t
  ```
-  
+
   The stationary steady-state population distribution $\boldsymbol{\bar{\omega}}$ is the eigenvector $\boldsymbol{\omega}$ with eigenvalue $(1+\bar{g}_n)$ of the matrix $\boldsymbol{\Omega}$ that satisfies the following version of {eq}`EqPopLOMstatmat2`.
-  
+
   ```{math}
   :label: EqPopLOMss
     (1+\bar{g}_n)\boldsymbol{\bar{\omega}} = \boldsymbol{\Omega}\boldsymbol{\bar{\omega}}
   ```
 
-  <!-- \begin{proposition} -->
+  ```{admonition} Proposition
+  :class: tip
   If the age $s=1$ immigration rate is $i_1>-(1-\rho_0)f_1$ and the other immigration rates are strictly positive $i_s>0$ for all $s\geq 2$ such that all elements of $\boldsymbol{\Omega}$ are nonnegative, then there exists a unique positive real eigenvector $\boldsymbol{\bar{\omega}}$ of the matrix $\boldsymbol{\Omega}$, and it is a stable equilibrium.
-  <!-- \end{proposition} -->
 
-  <!-- \begin{proof} -->
+  **Proof:**
   First, note that the matrix $\boldsymbol{\Omega}$ is square and non-negative.  This is enough for a general version of the Perron-Frobenius Theorem to state that a positive real eigenvector exists with a positive real eigenvalue. This is not yet enough for uniqueness. For it to be unique by a version of the Perron-Fobenius Theorem, we need to know that the matrix is irreducible. This can be easily shown. The matrix is of the form
-  
+
   $$
   \boldsymbol{\Omega} =
     \begin{bmatrix}
@@ -203,7 +210,7 @@ Immigration rates by age ($i_s$), residual, $E+S=100$
   $$
 
   Where each * is strictly positive. It is clear to see that taking powers of the matrix causes the sub-diagonal positive elements to be moved down a row and another row of positive entries is added at the top. None of these go to zero since the elements were all non-negative to begin with.
-  
+
   $$
   \boldsymbol{\Omega}^2 =
     \begin{bmatrix}
@@ -240,59 +247,48 @@ Immigration rates by age ($i_s$), residual, $E+S=100$
   Existence of an $m \in \mathbb{N}$ such that $\left(\bf\Omega^m\right)_{ij} \neq 0 ~~ ( > 0)$ is one of the definitions of an irreducible (primitive) matrix. It is equivalent to saying that the directed graph associated with the matrix is strongly connected. Now the Perron-Frobenius Theorem for irreducible matrices gives us that the equilibrium vector is unique.
 
   We also know from that theorem that the eigenvalue associated with the positive real eigenvector will be real and positive. This eigenvalue, $p$, is the Perron eigenvalue and it is the steady state population growth rate of the model. By the PF Theorem for irreducible matrices, $| \lambda_i | \leq p$ for all eigenvalues $\lambda_i$ and there will be exactly $h$ eigenvalues that are equal, where $h$ is the period of the matrix. Since our matrix $\bf\Omega$ is aperiodic, the steady state growth rate is the unique largest eigenvalue in magnitude. This implies that almost all initial vectors will converge to this eigenvector under iteration.
-  
-  <!-- \end{proof} -->
+  ```
 
   For a full treatment and proof of the Perron-Frobenius Theorem, see {cite}`Suzumura:1983`. Because the population growth process is exogenous to the model, we calibrate it to annual age data for age years $s=1$ to $s=100$.
 
   Figure {numref}`FigOrigVsFixSSpop` shows the steady-state population distribution $\boldsymbol{\bar{\omega}}$ and the population distribution after 120 periods $\boldsymbol{\hat{\omega}}_{120}$. Although the two distributions look very close to each other, they are not exactly the same.
 
-```{figure} ../theory/images/OrigVsFixSSpop.png
----
-height: 500px
-name: FigOrigVsFixSSpop
----
-Theoretical steady-state population distribution vs. population distribution at period $t=120$
-```
-
+  ```{figure} ../theory/images/OrigVsFixSSpop.png
+  ---
+  height: 500px
+  name: FigOrigVsFixSSpop
+  ---
+  Theoretical steady-state population distribution vs. population distribution at period $t=120$
+  ```
 
   Further, we find that the maximum absolute difference between the population levels $\hat{\omega}_{s,t}$ and $\hat{\omega}_{s,t+1}$ was $1.3852\times 10^{-5}$ after 160 periods. That is to say, that after 160 periods, given the estimated mortality, fertility, and immigration rates, the population has not achieved its steady state. For convergence in our solution method over a reasonable time horizon, we want the population to reach a stationary distribution after $T$ periods. To do this, we artificially impose that the population distribution in period $t=120$ is the steady-state. As can be seen from Figure {numref}`FigOrigVsFixSSpop`, this assumption is not very restrictive. Figure {numref}`FigImmRateChg` shows the change in immigration rates that would make the period $t=120$ population distribution equal be the steady-state. The maximum absolute difference between any two corresponding immigration rates in Figure {numref}`FigImmRateChg` is 0.0028.
 
-```{figure} ../theory/images/OrigVsAdjImm.png
----
-height: 500px
-name: FigImmRateChg
----
-Original immigration rates vs. adjusted immigration rates to make fixed steady-state population distribution
-```
+  ```{figure} ../theory/images/OrigVsAdjImm.png
+  ---
+  height: 500px
+  name: FigImmRateChg
+  ---
+  Original immigration rates vs. adjusted immigration rates to make fixed steady-state population distribution
+  ```
 
   The most recent year of population data come from {cite}`Census:2015` population estimates for both sexes for 2013. We those data and use the population transition matrix {eq}`EqPopLOMstatmat2` to age it to the current model year of 2015. We then use {eq}`EqPopLOMstatmat2` to generate the transition path of the population distribution over the time period of the model. Figure {numref}`FigPopDistPath` shows the progression from the 2013 population data to the fixed steady-state at period $t=120$. The time path of the growth rate of the economically active population $\tilde{g}_{n,t}$ is shown in Figure {numref}`FigGrowthPath`.
 
-```{figure} ../theory/images/PopDistPath.png
----
-height: 500px
-name: FigPopDistPath
----
-Exogenous stationary population distribution at periods along transition path
-```
+  ```{figure} ../theory/images/PopDistPath.png
+  ---
+  height: 500px
+  name: FigPopDistPath
+  ---
+  Exogenous stationary population distribution at periods along transition path
+  ```
 
-+++
-```{code-cell} ogusa-dev
-:tags: [hide-cell]
-from myst_nb import glue
-import ogusa.parameter_plots as pp
-from ogusa import Specifications
-p = Specifications()
-fig = pp.plot_pop_growth(p, start_year=2021)
-glue("pop_grow", fig, display=False)
-```
+  ```{figure} ../theory/images/GrowthPath.png
+  ---
+  height: 500px
+  name: FigGrowthPath
+  ---
+  Time path of the population growth rate $\tilde{g}_{n,t}$
+  ```
 
-```{glue:figure} pop_grow
-:figwidth: 750px
-:name: "FigGrowthPath"
-
-Exogenous stationary population growth rates at periods along transition path
-```
 
 [^calibage_note]: Theoretically, the model works without loss of generality for $S\geq 3$. However, because we are calibrating the ages outside of the economy to be one-fourth of $S$ (e.g., ages 21 to 100 in the economy, and ages 1 to 20 outside of the economy), it is convenient for $S$ to be at least 4.
 [^houseprob_note]: The parameter $\rho_s$ is the probability that a household of age $s$ dies before age $s+1$.

--- a/docs/book/content/calibration/earnings.md
+++ b/docs/book/content/calibration/earnings.md
@@ -29,7 +29,15 @@ In this specification, $w_t$ is an equilibrium wage representing a portion of la
 
 We calibrate deterministic ability paths such that each lifetime income group has a different life-cycle profile of earnings. The distribution on income and wealth are often focal components of macroeconomic models. As such, we use a calibration of deterministic lifetime ability paths from {cite}`DeBackerEtAl:2017b` that can represent U.S. earners in the top 1\% of the distribution of lifetime income. {cite}`PikettySaez:2003` show that income and wealth attributable to these households has shown the greatest growth in recent decades. The data come from the U.S. Internal Revenue Services's (IRS) Statistics of Income program (SOI) Continuous Work History Sample (CWHS). {cite}`DeBackerEtAl:2017b` match the SOI data with Social Security Administration (SSA) data on age and Current Population Survey (CPS) data on hours in order to generate a non-top-coded measure of hourly wage.
 
-+++
+```{figure} ../theory/images/ability_log_2D.png
+---
+height: 500px
+name: FigLogAbil
+---
+Exogenous life cycle income ability paths $\log(e_{j,s})$ with $S=80$ and $J=7$
+```
+
+<!-- +++
 ```{code-cell} ogusa-dev
 :tags: [hide-cell]
 from myst_nb import glue
@@ -46,6 +54,7 @@ glue("earnings_profiles", fig, display=False)
 
 Exogenous life cycle income ability paths $\log(e_{j,s})$ with $S=80$ and $J=7$
 ```
+-->
 
 
 Figure {numref}`FigLogAbil` shows a calibration for $J=7$ deterministic lifetime ability paths $e_{j,s}$ corresponding to labor income percentiles $\boldsymbol{\lambda}=[0.25, 0.25, 0.20, 0.10, 0.10, 0.09, 0.01]$. Because there are few individuals above age 80 in the data, {cite}`DeBackerEtAl:2017b` extrapolate these estimates for model ages 80-100 using an arctan function.
@@ -57,7 +66,7 @@ We calibrate the model such that each lifetime income group has a different life
 
   The SOI data we draw from are the Continuous Work History Sample (CWHS).  From this CWHS, we use a panel that is a 1-in-5000 random sample of tax filers from 1991 to 2009.  For each filer-year observation we are able to observe detailed information reported on Form 1040 and the associated forms and schedules.  We are also able to merge these tax data with Social Security Administration (SSA) records to get information on the age and gender of the primary and secondary filers.  Our model variable of effective labor units maps into wage rates, because the market wage rate in the model, $w_{t}$, is constant across households.  Earnings per hour thus depend upon effective labor units and equal $e_{j,s,t}\times w_{t}$ for household in lifetime income group $j$, with age $s$, in year $t$.  Income tax data, however, do not contain information on hourly earnings or hours works.  Rather, we only observe total earned income (wage and salaries plus self-employment income) over the tax year.  In order to find hourly earnings for tax filers, we use an imputation procedure.  This is described in detail in {cite}`DeBackerRamnath:2017`.  The methodology applies an imputation for hours worked for a filing unit based on a model of hours worked for a filing unit estimated from the Current Population Survey (CPS) for the years 1992-2010.[^retroquest_note] We then use the imputed hours to calculate hourly earnings rates for tax filing units in the CWHS.
 
-  We exclude from our sample filer-year observations with earned income (wages and salaries plus business income) of less than \$1,250. We further exclude those with positive annual wages, but with hourly wages below \$5.00 (in 2005\$). We also drop one observation where the hourly wage rate exceeds \$25,000.[^threshold_note] Economic life in the model runs from age 21 to 100. Our data have few observations on filers with ages exceeding 80 years old. Our sample is therefore restricted to those from ages 21 to 80. After these restrictions, our final sample size is 333,381 filer-year observations.
+  We exclude from our sample filer-year observations with earned income (wages and salaries plus business income) of less than \$1,250. We further exclude those with positive annual wages, but with hourly wages below \$5.00 (in 2005 \$). We also drop one observation where the hourly wage rate exceeds \$25,000.[^threshold_note] Economic life in the model runs from age 21 to 100. Our data have few observations on filers with ages exceeding 80 years old. Our sample is therefore restricted to those from ages 21 to 80. After these restrictions, our final sample size is 333,381 filer-year observations.
 
 (SecLFearnLifInc)=
 ## Lifetime Income
@@ -65,82 +74,80 @@ We calibrate the model such that each lifetime income group has a different life
   In our model, labor supply and savings, and thus lifetime income, are endogenous. We therefore define lifetime income as the present value of lifetime labor endowments and not the value of lifetime labor earnings. Note that our data are at the tax filing unit.  We take this unit to be equivalent to a household.  Because of differences in household structure (i.e., singles versus couples), our definition of lifetime labor income will be in per adult terms.  In particular, for filing units with a primary and secondary filer, our imputed wage represents the average hourly earnings between the two. When calculating lifetime income we assign single and couple households the same labor endowment.  This has the effect of making our lifetime income metric a per adult metric, there is therefore not an over-representation of couple households in the higher lifetime income groups simply because their time endowment is higher than for singles. We use the following approach to measure the lifetime income.
 
   First, since our panel data do not allow us to observe the complete life cycle of earnings for each household (because of sample attrition, death or the finite sample period of the data), we use an imputation to estimate wages in the years of the household's economic life for which they do not appear in the CWHS. To do this, we estimate the following equation, separately by household type (where household types are single male, single female, couple with male head, or couple with female head):
-  
-  <!-- \begin{equation}\label{wage_step1}
-    ln(w_{i,t}) = \alpha_{i} + \beta_{1}age_{i,t} + \beta_{2}age_{i,t}^{2} + \beta_{3}*age_{i,t}^{3} + \varepsilon_{i,t}
-  \end{equation} -->
 
-   ```{math}
+  ```{math}
   :label: wage_step1
     ln(w_{i,t}) = \alpha_{i} + \beta_{1}age_{i,t} + \beta_{2}age_{i,t}^{2} + \beta_{3}*age_{i,t}^{3} + \varepsilon_{i,t}
   ```
 
-  <!-- \begin{table}[htbp]\centering\captionsetup{width=5.8in}
-    \caption{\label{tab:wage_step1}\textbf{Initial Log Wage Regressions}}
-    \begin{threeparttable}
-    \begin{tabular}{>{\scriptsize}l |>{\scriptsize}c >{\scriptsize}c >{\scriptsize}c >{\scriptsize}c}
-    \hline\hline
-    \multicolumn{1}{c}{\scriptsize{Dependent}} & Single & Single & Married, & Married, \\[-2mm]
-    \multicolumn{1}{c}{\scriptsize{variables}}  & males & females & male head  & female head \\
-    \hline
-    $Age$ & 0.177*** & 0.143*** & 0.134*** & 0.065** \\
-          & (0.006) & (0.005) & (0.004) & (0.027) \\
-    $Age^{2}$ & -0.003*** & -0.002*** & -0.002*** & -0.000 \\
-              & (0.000) & (0.000) & (0.000) & (0.001) \\
-    $Age^{3}$ & 0.000*** & 0.000*** & 0.000*** & 0.000 \\
-              & (0.000) & (0.000) & (0.000) & (0.000) \\
-    Constant & -0.839*** & -0.648*** & -0.042 & 1.004*** \\
-             & (0.072) & (0.070) & (0.058) & (0.376) \\
-    \hline
-    Adj $R^{2}$  & -0.007 & 0.011 & -0.032 & -0.324 \\
-    Observations & 88,833 & 96,670 & 141,564 & 6,314 \\
-    \hline\hline
-    \end{tabular}
-    \begin{tablenotes}
-      \scriptsize{\item[]Source: CWHS data, 1991 -- 2009.
-      \item[**]Significant at the 5 percent level ($p<0.05$).
-      \item[***]Significant at the 1 percent level ($p<0.01$).}
-    \end{tablenotes}
-    \end{threeparttable}
-  \end{table} -->
-
-<div id="tab:wage_step1">
-
-|                       |              |              |              |             |
-|:----------------------|:------------:|:------------:|:------------:|:-----------:|
-|                       |    Single    |    Single    |   Married,   |  Married,   |
-|                       |    males     |   females    |  male head   | female head |
-| *A**g**e*             | 0.177\*\*\*  | 0.143\*\*\*  | 0.134\*\*\*  |  0.065\*\*  |
-|                       |   (0.006)    |   (0.005)    |   (0.004)    |   (0.027)   |
-| *A**g**e*<sup>2</sup> | -0.003\*\*\* | -0.002\*\*\* | -0.002\*\*\* |   -0.000    |
-|                       |   (0.000)    |   (0.000)    |   (0.000)    |   (0.001)   |
-| *A**g**e*<sup>3</sup> | 0.000\*\*\*  | 0.000\*\*\*  | 0.000\*\*\*  |    0.000    |
-|                       |   (0.000)    |   (0.000)    |   (0.000)    |   (0.000)   |
-| Constant              | -0.839\*\*\* | -0.648\*\*\* |    -0.042    | 1.004\*\*\* |
-|                       |   (0.072)    |   (0.070)    |   (0.058)    |   (0.376)   |
-| Adj *R*<sup>2</sup>   |    -0.007    |    0.011     |    -0.032    |   -0.324    |
-| Observations          |    88,833    |    96,670    |   141,564    |    6,314    |
-
-<span id="tab:wage_step1"
-label="tab:wage_step1"></span>**Initial Log Wage
-Regressions**
-
-</div>
-
-Source: CWHS data, 1991 – 2009.
-
-Significant at the 5 percent level (*p* &lt; 0.05).
-
-Significant at the 1 percent level (*p* &lt; 0.01).
-
-  The parameter estimates, including the household fixed effects, from Equation {eq}`wage_step1` are shown in Table {ref}`tab:wage_step1`. These estimates are then used to impute values for log wages in years of each households' economic life for which we do not have data.  This creates a balanced panel of log wages of households with heads aged 21 to 80. The actual and imputed wage values are then used to calculate the net present value of lifetime labor endowments per adult for each household. Specifically, we define lifetime income for household $i$ as:
+  The parameter estimates, including the household fixed effects, from Equation {eq}`wage_step1` are shown in {numref}`TabWage_step1`. These estimates are then used to impute values for log wages in years of each households' economic life for which we do not have data.  This creates a balanced panel of log wages of households with heads aged 21 to 80. The actual and imputed wage values are then used to calculate the net present value of lifetime labor endowments per adult for each household. Specifically, we define lifetime income for household $i$ as:
 
   ```{math}
-:label: eqn:LI
+  :label: eqn:LI
     LI_{i} = \sum_{t=21}^{80}\left(\frac{1}{1+r}\right)^{t-21}(w_{i,t}*4000)
- ```
+  ```
 
-  \noindent\noindent Note that households are all have the same time endowment in each year (4000 hours).  Thus the amount of the time endowment scales lifetime income up or down, but does not change the lifetime income of one household relative to another. This is not the case with the interest rate, $r$, which we fix at 4\%. Changes in the interest rate differentially impact the lifetime income calculation for different individuals because they may face different earnings profiles. For example, a higher interest rate would reduced the discounted present value of lifetime income for those individuals whose wage profiles peaked later in their economic life by a larger amount than it would reduce the discounted present value of lifetime income for individuals whose wage profiles peaked earlier.
+  ```{list-table} Initial log wage regressions. Source: CWHS data, 1991-2009. \*\* Significant at the 5-percent level ($p<0.05$). \*\*\* Significant at the 1-percent level ($p<0.01$).
+  :header-rows: 1
+  :name: TabWage_step1
+  * - Dependent variable
+    - Single male
+    - Single female
+    - Married male head
+    - Married female head
+  * - $Age$
+    - 0.177\*\*\*
+    - 0.143\*\*\*
+    - 0.134\*\*\*
+    - 0.065\*\*
+  * -
+    - (0.006)
+    - (0.005)
+    - (0.004)
+    - (0.027)
+  * - $Age^2$
+    - -0.003\*\*\*
+    - -0.002\*\*\*
+    - -0.002\*\*\*
+    - -0.000
+  * -
+    - (0.000)
+    - (0.000)
+    - (0.000)
+    - (0.001)
+  * - $Age^3$
+    - 0.000\*\*\*
+    - 0.000\*\*\*
+    - 0.000\*\*\*
+    - 0.000
+  * -
+    - (0.000)
+    - (0.000)
+    - (0.000)
+    - (0.000)
+  * - $Constant$
+    - -0.839\*\*\*
+    - -0.648\*\*\*
+    - -0.042
+    - 1.004\*\*\*
+  * -
+    - (0.072)
+    - (0.070)
+    - (0.058)
+    - (0.376)
+  * - Adjusted $R^2$
+    - -0.007
+    - 0.011
+    - -0.032
+    - -0.324
+  * - Observations
+    - 88,833
+    - 96,670
+    - 141,564
+    - 6,314
+  ```
+
+  Note that households are all have the same time endowment in each year (4000 hours). Thus the amount of the time endowment scales lifetime income up or down, but does not change the lifetime income of one household relative to another. This is not the case with the interest rate, $r$, which we fix at 4\%. Changes in the interest rate differentially impact the lifetime income calculation for different individuals because they may face different earnings profiles. For example, a higher interest rate would reduced the discounted present value of lifetime income for those individuals whose wage profiles peaked later in their economic life by a larger amount than it would reduce the discounted present value of lifetime income for individuals whose wage profiles peaked earlier.
 
 
 ## Profiles by Lifetime Income
@@ -150,7 +157,7 @@ Significant at the 1 percent level (*p* &lt; 0.01).
   :label: EqLfEarnLambda_j
     \lambda_{j}=[0.25, 0.25, 0.2, 0.1, 0.1, 0.09, 0.01]
   ```
-  
+
   That is, lifetime income group one includes those in below the 25th percentile, group two includes those from the 25th to the median, group three includes those from the median to the 70th percentile, group four includes those from the 70th to the 80th percentile, group 5 includes those from the 80th to 90th percentile, group 6 includes those from the 90th to 99th percentile, and group 7 consists of the top one percent in the lifetime income distribution.  Table {ref}`tab:li_group_stats` presents descriptive statistics for each of these groups.
 
   <!-- \begin{table}[htbp] \centering \captionsetup{width=6.0in}
@@ -215,7 +222,7 @@ CWHS data, 1991-2009, all nominal values in 2005$.
     ln(w_{i,t})=\alpha +  \beta_{1}age_{i,t} + \beta_{2}age_{i,t}^{2} + \beta_{3}*age_{i,t}^{3}+ \varepsilon_{i,t}
   \end{equation}
   The estimated parameters from equation {eq}`eqn:wage_profile` are given in Table {ref}`tab:wage_profiles`. The life-cycle earnings profiles implied by these parameters are plotted in Figure {numref}`FigLogAbil`. Note that there are few individuals above age 80 in the data. To extrapolate these estimates for model ages 80-100, we use an arctan function of the following form:
-  
+
   ```{math}
  :label: EqLfEarnArctan
     y = \left(\frac{-a}{\pi}\right)*arctan(bx+c)+\frac{a}{2}


### PR DESCRIPTION
This PR updates @chusloj's [PR #644](https://github.com/PSLmodels/OG-USA/pull/644) to the `PSLmodels/OG-USA` master. In particular, this PR demonstrates:
* how to format a proposition as in [`demographics.md` line 193](docs/book/content/calibration/demographics.md#L193). I wish we had a way to reference and number these definintion/proposition/theorem admonitions, but I haven't been able to figure it out yet.
* how to insert a figure as in [`demographics.md` line 61](docs/book/content/calibration/demographics.md#L61)
* how to format a table as in [`earnings.md` line 90](docs/book/content/calibration/earnings.md#L90)

There is a lot more to do in each of these files. But this should give us a template on how to do it.

cc: @jdebacker